### PR TITLE
Fix android fling for v6.0.1 compatible library

### DIFF
--- a/android/src/main/java/com/rnnestedscrollview/ReactNestedScrollView.java
+++ b/android/src/main/java/com/rnnestedscrollview/ReactNestedScrollView.java
@@ -283,9 +283,9 @@ public class ReactNestedScrollView extends NestedScrollView implements ReactClip
       postInvalidateOnAnimation();
 
       // END FB SCROLLVIEW CHANGE
-    } else {
-      super.fling(velocityY);
     }
+    //Fixed fling issue on support library 26 (see issue https://github.com/cesardeazevedo/react-native-nested-scroll-view/issues/16)
+    super.fling(velocityY);
 
     if (mSendMomentumEvents || isScrollPerfLoggingEnabled()) {
       mFlinging = true;


### PR DESCRIPTION
Fix android fling for v6.0.1 compatible library(react-native versions 0.55.4 or bellow)